### PR TITLE
Fix lint in playground

### DIFF
--- a/playground-common/README.md
+++ b/playground-common/README.md
@@ -56,7 +56,7 @@ Properties that will be set dynamically are kept in `playground.properties` file
 shared properties are kept in `androidx-shared.properties` file.
 The dynamic properties are read in the `playground` plugin and set on each project.
 
-There is a `VerifyPlaygroundGradlePropertiesTask` task that validates the contents of
+There is a `VerifyPlaygroundGradleConfigurationTask` task that validates the contents of
 `androidx-shared.properties` file as part of the main AndroidX build.
 
 ### Optional Dependencies

--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -33,6 +33,7 @@ android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.disableAutomaticComponentCreation=true
+android.experimental.lint.missingBaselineIsEmptyBaseline=true
 
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Since upgrading to AGP 7.3.0-alpha08, we no longer optionally set baseline
file during lint task configuration, since Gradle is smart enough to avoid
creating the file unnecessarily. This exposed a behavior difference in
how playground and aosp treats lint baseline files due to
`android.experimental.lint.missingBaselineIsEmptyBaseline=true` in
`gradle.properties`.

Currently our property validation only checks properties which are set
in androidx-shared.properties, so this was missed.

Test: cd activity && ./gradlew internal-testutils-common:lint
Change-Id: I48e50b499e15c379e484459c3a0ee77307a02963